### PR TITLE
Fix major memory leak in get_fantasy_model

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -246,11 +246,16 @@ class ExactGP(GP):
         self.train_inputs = None
         self.train_targets = None
         self.likelihood = None
+        # Clear hooks to avoid them being copied
+        self._load_state_dict_pre_hooks.clear()
         new_model = deepcopy(self)
         self.prediction_strategy = old_pred_strat
         self.train_inputs = old_train_inputs
         self.train_targets = old_train_targets
         self.likelihood = old_likelihood
+
+        # Clear hooks in the new model to remove any lingering references to the old model
+        new_model._load_state_dict_pre_hooks.clear()
 
         new_likelihood = old_likelihood.get_fantasy_likelihood(**fantasy_kwargs)
         new_model.likelihood = new_likelihood


### PR DESCRIPTION
Deep-copying the ExactGP model runs into issues as there are multiple `_WrappedHook` objects with the reference method `_load_state_hook_ignore_shapes` which point to the previous ExactGP object. Somehow, these old instances of ExactGP objects remain standing and are not freed up automatically by Python (probably as it doesn't go out of scope due to a remaining reference). 
Calling `gc.collect()` would take care of the dangling objects, but this operation is extremely slow if called at each iteration.
Our fix: Remove all hooks explicitly before creating a deepcopy of the ExactGP instance for further use.

![circular_references_9](https://github.com/user-attachments/assets/5918d2f5-34cd-43a1-9a54-21d9c1120152)
